### PR TITLE
Delete chunked-transfer-coding

### DIFF
--- a/ch/un/chunked-transfer-coding
+++ b/ch/un/chunked-transfer-coding
@@ -1,1 +1,0 @@
-{"name":"chunked-transfer-coding","vers":"0.1.0","deps":[],"cksum":"af7c3974a7dd781662081388e67b8798cd2e65da3ec3d2838a207d30663cab5c","features":{},"yanked":false}


### PR DESCRIPTION
I accidentally created this when publishing. The real library is `chunked_transfer` which is pushed.