### PR TITLE
Remove trailing slash from api URL

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,4 +1,4 @@
 {
   "dl": "https://crates.io/api/v1/crates",
-  "api": "https://crates.io/"
+  "api": "https://crates.io"
 }


### PR DESCRIPTION
While trying to migrate the crates.io backend over to `hyper`, we ran into the issue that cargo hits API endpoints with URLs like `https://crates.io//api/v1/crates/new` (`//` before `api`).  At the time, we rolled back the deploy and reverted the code in rust-lang/crates.io#1476 because it broke cargo API interactions.

By removing the trailing `/` in the configuration here, cargo clients will send a single `/` and we won't need special case handling on the backend.

I've looked though the history of `src/crates-io/lib.rs` in the `cargo` source, and as far back as rust-lang/cargo@9fba127 the code always appends `/api/v1` to the configured api URL.  This is included in the oldest git tag for cargo, `v0.0.1-pre`.