### PR TITLE
Add basic `README.md` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# The crates.io package index
+
+The [crates.io](https://crates.io/) package index contains the necessary metadata for [`cargo`](https://doc.rust-lang.org/cargo) to download crates and resolve their dependencies.
+
+The package index is available at:
+
+- <https://index.crates.io/> as an HTTP API ([sparse protocol](https://rust-lang.github.io/rfcs/2789-sparse-index.html))
+- <https://github.com/rust-lang/crates.io-index> as a git repository
+
+The index format is described in detail in [The Cargo Book](https://doc.rust-lang.org/cargo/reference/registry-index.html#index-format).
+
+The crates.io index is maintained by the [crates.io team](https://www.rust-lang.org/governance/teams/dev-tools#team-crates-io).


### PR DESCRIPTION
This roughly describes the contents of this repository and links some of the relevant documentation. This should also be uploaded in rendered form to the sparse index as an `index.html` file.

Related:

- https://github.com/rust-lang/crates.io/issues/8617